### PR TITLE
Delay fix

### DIFF
--- a/src/main/java/com/example/addon/modules/TridentDupe.java
+++ b/src/main/java/com/example/addon/modules/TridentDupe.java
@@ -59,8 +59,6 @@ public class TridentDupe extends Module {
         .build()
     );
 
-    private final Queue<Packet<?>> delayedPackets = new LinkedList<>();
-
     public TridentDupe() {
         super(com.example.addon.TridentDupe.CATEGORY, "trident-dupe", "Dupes tridents in first hotbar slot. / / Killet / / Laztec / / Ionar");
     }
@@ -81,7 +79,8 @@ public class TridentDupe extends Module {
         if (!cancel)
             return;
 
-        MutableText packetStr = Text.literal(event.packet.toString()).formatted(Formatting.WHITE);
+        // MutableText packetStr = Text.literal(event.packet.toString()).formatted(Formatting.WHITE);
+        // System.out.println(packetStr);
 
         event.cancel();
     }
@@ -92,25 +91,6 @@ public class TridentDupe extends Module {
         if (mc.player == null)
             return;
 
-        for (int i = 0; i < 9; i++)
-        {
-            if (mc.player.getInventory().getStack((i)).getItem() == Items.TRIDENT)
-            {
-                Integer currentHotbarDamage = mc.player.getInventory().getStack((i)).getDamage();
-
-            }
-        }
-
-        PlayerInteractItemC2SPacket pckt = new PlayerInteractItemC2SPacket(Hand.MAIN_HAND, 10, -57.0f, 66.29f);
-
-        Int2ObjectMap<ItemStack> modifiedStacks = new Int2ObjectOpenHashMap<>();
-
-        modifiedStacks.put(3,  mc.player.getInventory().getStack(mc.player.getInventory().selectedSlot));
-        modifiedStacks.put(36,  mc.player.getInventory().getStack(mc.player.getInventory().selectedSlot));
-
-        ClickSlotC2SPacket packet = new ClickSlotC2SPacket(0, 15, 0, 0, SlotActionType.SWAP,
-            new ItemStack(Items.AIR), modifiedStacks);
-
         scheduledTasks.clear();
         dupe();
 
@@ -120,16 +100,14 @@ public class TridentDupe extends Module {
     {
         int delayInt = (delay.get()).intValue()*100;
 
-        System.out.println(delayInt);
-
         int lowestHotbarSlot = 0;
         int lowestHotbarDamage = 1000;
         for (int i = 0; i < 9; i++)
         {
             if (mc.player.getInventory().getStack((i)).getItem() == Items.TRIDENT)
             {
-                Integer currentHotbarDamage = mc.player.getInventory().getStack((i)).getDamage();
-                if(lowestHotbarDamage > currentHotbarDamage) { lowestHotbarSlot = i; lowestHotbarDamage = currentHotbarDamage;}
+                int currentHotbarDamage = mc.player.getInventory().getStack((i)).getDamage();
+                if (lowestHotbarDamage > currentHotbarDamage) { lowestHotbarSlot = i; lowestHotbarDamage = currentHotbarDamage;}
 
             }
         }

--- a/src/main/java/com/example/addon/modules/TridentDupe.java
+++ b/src/main/java/com/example/addon/modules/TridentDupe.java
@@ -5,9 +5,6 @@
 
 package com.example.addon.modules;
 
-import meteordevelopment.meteorclient.systems.modules.Module;
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import meteordevelopment.meteorclient.events.game.GameLeftEvent;
 import meteordevelopment.meteorclient.events.game.OpenScreenEvent;
 import meteordevelopment.meteorclient.events.packets.PacketEvent;
@@ -16,13 +13,11 @@ import meteordevelopment.meteorclient.settings.BoolSetting;
 import meteordevelopment.meteorclient.settings.DoubleSetting;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.settings.SettingGroup;
-import meteordevelopment.meteorclient.utils.player.ChatUtils;
+import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
 import meteordevelopment.orbit.EventPriority;
 import net.minecraft.client.gui.screen.DisconnectedScreen;
-import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.c2s.play.*;
 import net.minecraft.screen.slot.SlotActionType;
 import net.minecraft.text.MutableText;
@@ -33,7 +28,9 @@ import net.minecraft.util.Pair;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 public class TridentDupe extends Module {
     // Coded by Killet Laztec & Ionar :3
@@ -79,8 +76,8 @@ public class TridentDupe extends Module {
         if (!cancel)
             return;
 
-        // MutableText packetStr = Text.literal(event.packet.toString()).formatted(Formatting.WHITE);
-        // System.out.println(packetStr);
+//        MutableText packetStr = Text.literal(event.packet.toString()).formatted(Formatting.WHITE);
+//        System.out.println(packetStr);
 
         event.cancel();
     }
@@ -98,8 +95,6 @@ public class TridentDupe extends Module {
 
     private void dupe()
     {
-        int delayInt = (delay.get()).intValue()*100;
-
         int lowestHotbarSlot = 0;
         int lowestHotbarDamage = 1000;
         for (int i = 0; i < 9; i++)
@@ -135,22 +130,25 @@ public class TridentDupe extends Module {
             if(dropTridents.get()) mc.interactionManager.clickSlot(mc.player.currentScreenHandler.syncId, 44, 0, SlotActionType.THROW, mc.player);
 
             cancel = true;
-            scheduleTask2(this::dupe, delayInt);
-        }, delayInt);
+            scheduleTask2(this::dupe, delay.get() * 100);
+        });
     }
 
 
     private boolean cancel = true;
 
     private final List<Pair<Long, Runnable>> scheduledTasks = new ArrayList<>();
-    private final List<Pair<Long, Runnable>> scheduledTasks2 = new ArrayList<>();
+    private final List<Pair<Double, Runnable>> scheduledTasks2 = new ArrayList<>();
 
-    public void scheduleTask(Runnable task, long delayMillis) {
-        long executeTime = System.currentTimeMillis() + delayMillis;
+    public void scheduleTask(Runnable task) {
+        // throw trident
+        long executeTime = System.currentTimeMillis() + 500;
         scheduledTasks.add(new Pair<>(executeTime, task));
     }
-    public void scheduleTask2(Runnable task, long delayMillis) {
-        long executeTime = System.currentTimeMillis() + delayMillis;
+
+    public void scheduleTask2(Runnable task, double delayMillis) {
+        // dupe loop
+        double executeTime = System.currentTimeMillis() + delayMillis;
         scheduledTasks2.add(new Pair<>(executeTime, task));
     }
 
@@ -168,11 +166,12 @@ public class TridentDupe extends Module {
                 }
             }
         }
+
         {
-            Iterator<Pair<Long, Runnable>> iterator = scheduledTasks2.iterator();
+            Iterator<Pair<Double, Runnable>> iterator = scheduledTasks2.iterator();
 
             while (iterator.hasNext()) {
-                Pair<Long, Runnable> entry = iterator.next();
+                Pair<Double, Runnable> entry = iterator.next();
                 if (entry.getLeft() <= currentTime) {
                     entry.getRight().run();
                     iterator.remove(); // Remove executed task from the list
@@ -192,5 +191,4 @@ public class TridentDupe extends Module {
             toggle();
         }
     }
-
 }


### PR DESCRIPTION
I made this fix before patch on 2b2t

Throwing delay is now 500 ms, it is minimum required time to hold a trident between throws
Now the slider affects delay between dupes only, so 0 delay actually works, making the duping twice as fast!
